### PR TITLE
Fix stub quote ask generation range

### DIFF
--- a/quickfix-server/src/main/java/dev/max/quickfix/server/integration/stub/StubMarketDataSource.java
+++ b/quickfix-server/src/main/java/dev/max/quickfix/server/integration/stub/StubMarketDataSource.java
@@ -107,8 +107,8 @@ public class StubMarketDataSource implements MarketDataSource {
     private static class StubQuoteGenerator {
         public static Quote generate(String instrument) {
             var price = prices.get(instrument);
-            var bid = RANDOM.nextDouble(price, price + 10.0);
-            var ask = RANDOM.nextDouble(price, price - 10.0);
+            var bid = RANDOM.nextDouble(price - 10.0, price);
+            var ask = RANDOM.nextDouble(price, price + 10.0);
             return new Quote(
                     instrument,
                     bid,


### PR DESCRIPTION
## Summary
- ensure stub quote generator produces valid bid/ask ranges
- guarantee bid price is below ask price

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c15c1b2fb883238acb272bb7f0ba4e